### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name"        : "iandunn/wp-cli-plugin-active-on-sites",
 	"description" : "A WP-CLI command to list all sites in a Multisite network that have activated a given plugin",
+	"type"        : "wp-cli-package",
 	"homepage"    : "https://github.com/iandunn/wp-cli-plugin-active-on-sites",
 	"license"     : "GPLv2",
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
