### PR TITLE
Allow configurable output suitable for piping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ A [WP-CLI](http://wp-cli.org/) command to list all sites in a Multisite network 
 
 `wp plugin active-on-sites <plugin_slug>`
 
+### Options
+[--field=<field>]
+	Prints the value of a single field for each site.
+[--fields=<fields>]
+        Comma-separated list of fields to show.
+[--format=<format>]
+        Render output in a particular format.
+
 ## Example
 
 ```shell
@@ -20,14 +28,14 @@ Checking each site  100% [==================================================] 0:
 
 Sites where eu-cookie-law-widget is active:
 +---------+----------------------------------------+
-| Site ID | Site URL                               |
+| blog_id | url                                    |
 +---------+----------------------------------------+
-| 320     | 2014.madrid.wordcamp.dev/              |
-| 371     | 2014.paris.wordcamp.dev/               |
-| 413     | 2015.london.wordcamp.dev/              |
-| 464     | 2015.milano.wordcamp.dev/              |
-| 522     | 2016.geneva.wordcamp.dev/              |
-| 571     | 2016.belfast.wordcamp.dev/             |
-| 654     | 2017.europe.wordcamp.dev/              |
+| 320     | http://2014.madrid.wordcamp.dev/       |
+| 371     | http://2014.paris.wordcamp.dev/        |
+| 413     | http://2015.london.wordcamp.dev/       |
+| 464     | http://2015.milano.wordcamp.dev/       |
+| 522     | http://2016.geneva.wordcamp.dev/       |
+| 571     | http://2016.belfast.wordcamp.dev/      |
+| 654     | http://2017.europe.wordcamp.dev/       |
 +---------+----------------------------------------+
 ```


### PR DESCRIPTION
This adds format, field, and fields as valid arguments. The goal is to allow the piping of output from this command to another wp-cli command. For example, `wp plugin active-on-sites contact-form-7 --field=url | xargs -n 1 -I % wp user list --role=administrator --fields=user_login,display_name,user_email --format=csv --url=%` would get you all the administrators on sites with this plugin activated.